### PR TITLE
Fixes insert URL/email in Firefox put cursor after closing of `a` tag

### DIFF
--- a/src/lib/defaultCommands.js
+++ b/src/lib/defaultCommands.js
@@ -553,7 +553,7 @@ var defaultCmds = {
 							'<a href="' +
 							'mailto:' + escape.entities(email) + '">' +
 								escape.entities((text || email)) +
-							'</a>'
+							'</a><span></span>'
 						);
 					} else {
 						editor.execCommand('createlink', 'mailto:' + email);
@@ -613,7 +613,7 @@ var defaultCmds = {
 					editor.wysiwygEditorInsertHtml(
 						'<a href="' + escape.entities(url) + '">' +
 							escape.entities(text) +
-						'</a>'
+						'</a><span></span>'
 					);
 				} else {
 					editor.execCommand('createlink', url);


### PR DESCRIPTION
References:
https://github.com/mybb/mybb/issues/3290
https://github.com/samclarke/SCEditor/issues/644